### PR TITLE
feat: add locale configuration for UK and US

### DIFF
--- a/src/studentsai/config/locales.js
+++ b/src/studentsai/config/locales.js
@@ -1,0 +1,65 @@
+/**
+ * File: locales.js
+ * Purpose: Defines locale-specific configuration for StudentsAI experiences
+ * Location: src/studentsai/config/
+ */
+
+export const Locales = {
+  'en-GB': {
+    label: 'English (United Kingdom)',
+    spelling: {
+      colour: 'colour',
+      programme: 'programme',
+      organisation: 'organisation',
+      centre: 'centre',
+      practise: 'practise',
+    },
+    grammar: {
+      collectiveNouns: 'Often treated as plural (e.g., "the team are")',
+      presentPerfectUsage: 'Prefer present perfect with recent actions ("I have just eaten")',
+      quotationMarks: 'Single quotation marks are standard',
+    },
+    dates: {
+      format: 'DD/MM/YYYY',
+      example: '14/07/2024',
+      weekStart: 'Monday',
+    },
+    academicTerms: {
+      undergraduateYear: ['first year', 'second year', 'third year', 'fourth year'],
+      periods: ['autumn term', 'spring term', 'summer term'],
+      gradingScale: 'First, Upper Second (2:1), Lower Second (2:2), Third',
+      advisors: 'personal tutor',
+    },
+  },
+  'en-US': {
+    label: 'English (United States)',
+    spelling: {
+      colour: 'color',
+      programme: 'program',
+      organisation: 'organization',
+      centre: 'center',
+      practise: 'practice',
+    },
+    grammar: {
+      collectiveNouns: 'Typically treated as singular (e.g., "the team is")',
+      presentPerfectUsage: 'Simple past common for recent actions ("I just ate")',
+      quotationMarks: 'Double quotation marks are standard',
+    },
+    dates: {
+      format: 'MM/DD/YYYY',
+      example: '07/14/2024',
+      weekStart: 'Sunday',
+    },
+    academicTerms: {
+      undergraduateYear: ['freshman', 'sophomore', 'junior', 'senior'],
+      periods: ['fall semester', 'spring semester', 'summer session'],
+      gradingScale: 'A, B, C, D, F',
+      advisors: 'academic advisor',
+    },
+  },
+};
+
+export function getLocaleConfig(locale = 'en-GB') {
+  return Locales[locale] || Locales['en-GB'];
+}
+


### PR DESCRIPTION
## Summary
- add locale configuration file for StudentsAI with UK and US English distinctions
- cover spelling, grammar, date formats, and academic terminology for each locale
- provide helper to retrieve locale config with a British English fallback

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d1df666d48832abfbeec0d00de0258