### PR TITLE
Add Stripe payment configuration stub

### DIFF
--- a/src/studentsai/config/payments.js
+++ b/src/studentsai/config/payments.js
@@ -1,0 +1,15 @@
+/**
+ * File: payments.js
+ * Purpose: Stub configuration for StudentsAI payment integration with Stripe
+ * Location: src/studentsai/config/
+ */
+
+export const Payments = {
+  provider: 'Stripe',
+  earlyBirdPrice: 29,
+  prelaunchPrice: 59,
+  launchOfferPrice: 99,
+  regularPrice: 199,
+  currency: 'GBP',
+  testKey: process.env.STRIPE_TEST_KEY || '',
+};


### PR DESCRIPTION
## Summary
- add a StudentsAI payments configuration that stubs the Stripe integration with tier pricing and currency settings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1e0692f44832aab64368fab902830